### PR TITLE
[WIP] Add rounds to game JSON

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -8,7 +8,8 @@ class GamesController < ApplicationController
 
   def show
     if request.xhr?
-      render json: { game: GameSerializer.new(game, viewer: current_user) }
+      render json: { game: GameSerializer.new(game, viewer: current_user), },
+        include: 'rounds.turns'
     else
       view = Games::ShowView.new(user: current_user, game: game)
       render "games/show", locals: { view: view }

--- a/app/javascript/components/Games/Show/View.js
+++ b/app/javascript/components/Games/Show/View.js
@@ -52,7 +52,9 @@ export default class View extends React.Component {
         </div>
       )
 
-      const turns = this.props.game.turns;
+      const turns = this.props.game.rounds.reduce((acc, round) => {
+        return acc.concat(round.turns)
+      }, [])
       const disabled = turns.length && turns[turns.length - 1].userId === players.viewer.id
       const turnListItems = turns.map((turn, index) => {
         const match = turn.match

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -1,6 +1,4 @@
 class Round < ApplicationRecord
-
   belongs_to :game
   has_many :turns
-
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,7 +1,7 @@
 class GameSerializer < ActiveModel::Serializer
   attributes :id, :status, :players
 
-  has_many :turns
+  has_many :rounds
 
   def players
     user_games = UserGame.includes(:user).where(game_id: object.id)

--- a/app/serializers/round_serializer.rb
+++ b/app/serializers/round_serializer.rb
@@ -1,7 +1,5 @@
 class RoundSerializer < ActiveModel::Serializer
-  attributes :game_id, :turn_count
+  attributes :game_id
 
-  def turn_count
-    object.turns.count
-  end
+  has_many :turns
 end

--- a/app/serializers/round_serializer.rb
+++ b/app/serializers/round_serializer.rb
@@ -1,0 +1,7 @@
+class RoundSerializer < ActiveModel::Serializer
+  attributes :game_id, :turn_count
+
+  def turn_count
+    object.turns.count
+  end
+end

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react-redux-router": "^0.0.5",
     "redux": "^3.7.1",
     "redux-thunk": "^2.2.0",
-    "trackstack": "^0.0.22"
+    "trackstack": "file:../framework"
   },
   "devDependencies": {
     "@types/node": "^8.0.47",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react-redux-router": "^0.0.5",
     "redux": "^3.7.1",
     "redux-thunk": "^2.2.0",
-    "trackstack": "file:../framework"
+    "trackstack": "^0.0.23"
   },
   "devDependencies": {
     "@types/node": "^8.0.47",

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -43,13 +43,12 @@ RSpec.describe GamesController, type: :controller do
       expect(flash[:error]).to be_nil
     end
 
-    fit "renders game json" do
+    it "renders game json" do
       turn = create(:turn, game: @game, user: @user, round: @round)
       sign_in @user
       get "show", { params: { id: @game.id }, xhr: true}
 
       json = JSON.parse(response.body)
-      binding.pry
       game = json["game"]
       rounds = game["rounds"]
       expect(rounds.count).to equal(1)

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GamesController, type: :controller do
     @request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:facebook]
 
     @game = create(:game)
-    round = create(:round, game: @game)
+    @round = create(:round, game: @game)
     @user = create(:user, :facebook)
     user_2 = create(:user, :facebook)
     user_game = create(:user_game, user_id: @user.id, game_id: @game.id)
@@ -41,6 +41,19 @@ RSpec.describe GamesController, type: :controller do
 
       expect(response.status).to eq(200)
       expect(flash[:error]).to be_nil
+    end
+
+    fit "renders game json" do
+      turn = create(:turn, game: @game, user: @user, round: @round)
+      sign_in @user
+      get "show", { params: { id: @game.id }, xhr: true}
+
+      json = JSON.parse(response.body)
+      binding.pry
+      game = json["game"]
+      rounds = game["rounds"]
+      expect(rounds.count).to equal(1)
+      expect(rounds.first["turns"].count).to equal(1)
     end
   end
 

--- a/spec/models/turn_spec.rb
+++ b/spec/models/turn_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Turn, type: :model do
       user_2 = create(:user, :facebook)
       game = create(:game, status: 0)
       round = create(:round, game: game)
-
       turn = create(:turn,
         game: game,
         user: user,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,9 +5192,8 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
-trackstack@^0.0.22:
+"trackstack@file:../framework":
   version "0.0.22"
-  resolved "https://registry.yarnpkg.com/trackstack/-/trackstack-0.0.22.tgz#59b0817a4162f195fb24c7cdd5042631b7a996cb"
   dependencies:
     levenshtein "^1.0.5"
     redux "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,8 +5192,9 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
-"trackstack@file:../framework":
-  version "0.0.22"
+trackstack@^0.0.23:
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/trackstack/-/trackstack-0.0.23.tgz#1fbc16c8a8d6f7f4644115bc204682cba30054d5"
   dependencies:
     levenshtein "^1.0.5"
     redux "^3.7.2"


### PR DESCRIPTION
Instead of return a flat list of turns for a game, it makes more sense to return turns grouped by round. Each method provides easy access to a flat list of turns, but grouping by round gives us another level of information.